### PR TITLE
fix(embroider-3): checks for all possible decorators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --no-lockfile
@@ -57,21 +57,16 @@ jobs:
       fail-fast: false
       matrix:
         try-scenario:
-          - ember-lts-3.28
-          - ember-4.0
-          - ember-lts-4.4
-          - ember-release
-          - ember-beta
-          - ember-canary
-          # - embroider-safe
-          # - embroider-optimized
+          - ember-4.8
+          - embroider-safe
+          - embroider-optimized
 
     steps:
       - uses: actions/checkout@v3
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile

--- a/addon/-private/options.js
+++ b/addon/-private/options.js
@@ -4,6 +4,8 @@ import { isDescriptor } from '../utils/utils';
 const { keys } = Object;
 const OPTION_KEYS = '__option_keys__';
 
+const POSSIBLE_DECORATORS = ['AliasDecoratorImpl', 'ComputedDecoratorImpl'];
+
 const OptionsObject = EmberObject.extend({
   toObject() {
     return this[OPTION_KEYS].reduce((obj, key) => {
@@ -17,12 +19,19 @@ export default class Options {
   constructor({ model, attribute, options = {} }) {
     const optionKeys = keys(options);
     const createParams = { [OPTION_KEYS]: optionKeys, model, attribute };
+    const someOptionsAreCPs = optionKeys.some((key) => {
+      return (
+        isDescriptor(options[key]) ||
+        POSSIBLE_DECORATORS.includes(options[key]?.constructor?.name)
+      );
+    });
 
     // If any of the options is a CP, we need to create a custom class for it
-    if (optionKeys.some((key) => isDescriptor(options[key]))) {
+    if (someOptionsAreCPs) {
       return OptionsObject.extend(options).create(createParams);
     }
 
     return OptionsObject.create(createParams, options);
   }
 }
+

--- a/addon/-private/options.js
+++ b/addon/-private/options.js
@@ -34,4 +34,3 @@ export default class Options {
     return OptionsObject.create(createParams, options);
   }
 }
-

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const getChannelURL = require('ember-source-channel-url');
 const { embroiderSafe, embroiderOptimized } = require('@embroider/test-setup');
 
 module.exports = async function () {
@@ -8,59 +7,11 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
-        name: 'ember-lts-3.28',
+        name: 'ember-4.8',
         npm: {
           devDependencies: {
-            'ember-source': '~3.28.0',
-            'ember-data': '~3.28.0',
-          },
-        },
-      },
-      {
-        name: 'ember-4.0',
-        npm: {
-          devDependencies: {
-            'ember-source': '~4.0.0',
-            'ember-data': '~4.0.0',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-4.4',
-        npm: {
-          devDependencies: {
-            'ember-source': '~4.4.0',
-            'ember-data': '~4.4.0',
-          },
-        },
-      },
-      {
-        name: 'ember-release',
-        npm: {
-          devDependencies: {
-            '@ember/string': '3.0.1',
-            'ember-source': await getChannelURL('release'),
-            'ember-data': 'latest',
-          },
-        },
-      },
-      {
-        name: 'ember-beta',
-        npm: {
-          devDependencies: {
-            '@ember/string': '3.0.1',
-            'ember-source': await getChannelURL('beta'),
-            'ember-data': 'beta',
-          },
-        },
-      },
-      {
-        name: 'ember-canary',
-        npm: {
-          devDependencies: {
-            '@ember/string': '3.0.1',
-            'ember-source': await getChannelURL('canary'),
-            'ember-data': 'canary',
+            'ember-source': '~4.8.0',
+            'ember-data': '~4.8.0',
           },
         },
       },

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "webpack": "^5.74.0"
   },
   "engines": {
-    "node": "14.* || 16.* || >= 18"
+    "node": "16.* || >= 18"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
Refs [#733](https://github.com/adopted-ember-addons/ember-cp-validations/issues/733)

Changes proposed:

 - Currently, if any of the `options` is a CP, we create a custom class for it
 - But the current code ignores `computed` decorators like `AliasDecoratorImpl` (constructor name) in which case the Error `"EmberObject.create no longer supports computed..."` is still thrown. This is happening on an `ember-addon v1` on `Ember 4.12` during the embroider-safe scenario (`embroider v3`)
 - This PR is meant to handle all possible scenarios where a property is either a "traditional" computed property or a computed "decorator" property.
